### PR TITLE
feat(compilation): import rules in custom namespace

### DIFF
--- a/source/compilation/getModelFromSource.ts
+++ b/source/compilation/getModelFromSource.ts
@@ -20,12 +20,13 @@ const IMPORT_KEYWORD = 'importer!'
  * ```yaml
  * importer!:
  *  depuis:
- *    nom: 'my-external-package'
- *    source: 'my-external-package.model.yaml'
+ *    nom: my-external-package
+ *    source: my-external-package.model.yaml
+ *  dans: root
  *  les règles:
  *    - règle 1
  *    - règle 2:
- *      question: 'Quelle est la valeur de la règle 2 ?'
+ *      question: Quelle est la valeur de la règle 2 ?
  */
 export type ImportMacro = {
   depuis: {
@@ -37,6 +38,8 @@ export type ImportMacro = {
     // The URL of the package, used for the documentation.
     url?: string
   }
+  // The namespace where to import the rules.
+  dans?: string
   // List of rules to import from the package.
   // They could be specified by their name, or by the name and the list of
   // properties to override or add.
@@ -267,7 +270,7 @@ function resolveImports(
             rule,
           )
           return [
-            ruleName,
+            importMacro.dans ? `${importMacro.dans} . ${ruleName}` : ruleName,
             removeRawNodeNom(ruleWithUpdatedDescription, ruleName),
           ]
         }

--- a/source/compilation/index.ts
+++ b/source/compilation/index.ts
@@ -34,6 +34,7 @@ importer!:
   	nom: <npm_package_name>
 	source: <path_to_the_model_file> (optional)
 	url: <url_to_the_package_documentation> (optional)
+  dans: <namespace> (optional)
   les règles:
     - <rule_name_from_the_npm_package>
     - <rule_name_from_the_npm_package>:

--- a/test/compilation/data/complex-deps-with-namespace-import.publicodes
+++ b/test/compilation/data/complex-deps-with-namespace-import.publicodes
@@ -1,0 +1,7 @@
+ importer!:
+  depuis:
+    nom: my-external-package
+    source: ./my-external-package.model.json
+  dans: pkg
+  les règles:
+     - complex

--- a/test/compilation/data/rules-doublon-with-namespace.publicodes
+++ b/test/compilation/data/rules-doublon-with-namespace.publicodes
@@ -1,0 +1,11 @@
+importer!:
+  depuis:
+    nom: 'my-external-package'
+    source: './my-external-package.model.json'
+  dans: pkg
+  les règles:
+    - root . b
+
+pkg . root:
+pkg . root . c:
+  titre: Conflicting rule with dependency of 'root . b' in my-external-package imported in 'pkg'

--- a/test/compilation/getModelFromSource.test.ts
+++ b/test/compilation/getModelFromSource.test.ts
@@ -151,4 +151,46 @@ Ajout d'une description`,
       getModelFromSource(join(testDataDir, baseName))
     }).toThrow(`[${baseName}] La règle 'root . c' est déjà définie`)
   })
+
+  it('should import a rule from a package with all dependencies from a complex formula in a custom namespace', () => {
+    expect(
+      getModelFromSource(
+        join(testDataDir, 'complex-deps-with-namespace-import.publicodes'),
+      ),
+    ).toEqual({
+      'pkg . complex': {
+        formule: {
+          somme: ['d', 'root'],
+        },
+        description: updatedDescription,
+      },
+      'pkg . root': {
+        formule: 'a * b',
+        description: updatedDescription,
+      },
+      'pkg . root . a': {
+        formule: 10,
+        description: updatedDescription,
+      },
+      'pkg . root . b': {
+        formule: 'root . c * 2',
+        description: updatedDescription,
+      },
+      'pkg . root . c': {
+        formule: 20,
+        description: updatedDescription,
+      },
+      'pkg . root 2': {
+        formule: 20,
+        résumé: 'Résumé root 2',
+        description: updatedDescription,
+      },
+      'pkg . d': {
+        formule: {
+          variations: [{ si: 'root 2 > 10', alors: 10 }, { sinon: 'root 2' }],
+        },
+        description: updatedDescription,
+      },
+    })
+  })
 })

--- a/test/compilation/getModelFromSource.test.ts
+++ b/test/compilation/getModelFromSource.test.ts
@@ -193,4 +193,11 @@ Ajout d'une description`,
       },
     })
   })
+
+  it('should throw an error if there is conflict between an imported rule and a base rule with a custom namespace', () => {
+    const baseName = 'rules-doublon-with-namespace.publicodes'
+    expect(() => {
+      getModelFromSource(join(testDataDir, baseName))
+    }).toThrow(`[${baseName}] La règle 'pkg . root . c' est déjà définie`)
+  })
 })


### PR DESCRIPTION
Closes #15 by adding the `dans` attribute in the `importer!` meta-mechanism allowing to import rules in a custom namespace.