### PR TITLE
fix(compilation): avoid to skip rule to import

### DIFF
--- a/source/compilation/resolveImports.ts
+++ b/source/compilation/resolveImports.ts
@@ -281,7 +281,16 @@ export function resolveImports(
         const ruleDeps = getDependencies(engine, rule)
           .filter(([ruleDepName, _]) => {
             // Avoid to overwrite the updatedRawNode
-            return !accFind(acc, ruleDepName)
+            return (
+              !accFind(acc, ruleDepName) &&
+              // The dependency is part of the rule to import so we don't want to handle it now
+              !rulesToImport.find(({ ruleName: ruleToImportName }) => {
+                const theDepIsARuleToImport =
+                  ruleName !== ruleToImportName &&
+                  ruleToImportName === ruleDepName
+                return theDepIsARuleToImport
+              })
+            )
           })
           .map(([ruleName, ruleNode]) => {
             return getUpdatedRule(ruleName, ruleNode)

--- a/test/compilation/data/my-external-package.model.json
+++ b/test/compilation/data/my-external-package.model.json
@@ -27,5 +27,9 @@
         { "sinon": "root 2" }
       ]
     }
+  },
+  "e": {
+    "question": "Question ?",
+    "formule": 10
   }
 }

--- a/test/compilation/data/updated-attrs-from-deps-import.publicodes
+++ b/test/compilation/data/updated-attrs-from-deps-import.publicodes
@@ -1,0 +1,8 @@
+importer!:
+  depuis:
+    nom: 'my-external-package'
+    source: './my-external-package.model.json'
+  les règles:
+    - root . b
+    - root . c:
+        titre: "Ajout d'un titre"

--- a/test/compilation/data/updated-attrs-import.publicodes
+++ b/test/compilation/data/updated-attrs-import.publicodes
@@ -6,6 +6,9 @@ importer!:
     - root . a:
         titre: "Ajout d'un titre"
     - root . c:
-        description: "Ajout d'une description" 
+        description: "Ajout d'une description"
     - root 2:
-        résumé: "Modification d'un résumé" 
+        résumé: "Modification d'un résumé"
+    - e:
+        résumé: Lorem ipsum
+        question:

--- a/test/compilation/getModelFromSource.test.ts
+++ b/test/compilation/getModelFromSource.test.ts
@@ -77,6 +77,30 @@ Ajout d'une description`,
         résumé: "Modification d'un résumé",
         description: updatedDescription,
       },
+      e: {
+        formule: 10,
+        question: null,
+        description: updatedDescription,
+        résumé: 'Lorem ipsum',
+      },
+    })
+  })
+
+  it('should import a rule from a package with all updated attributes even in imported rule deps', () => {
+    expect(
+      getModelFromSource(
+        join(testDataDir, 'updated-attrs-from-deps-import.publicodes'),
+      ),
+    ).toEqual({
+      'root . b': {
+        formule: 'root . c * 2',
+        description: updatedDescription,
+      },
+      'root . c': {
+        formule: 20,
+        titre: "Ajout d'un titre",
+        description: updatedDescription,
+      },
     })
   })
 


### PR DESCRIPTION
When a rule is a dependency of a rule to import and a rule to import itself, we need to be able to override attributes if needed.