### PR TITLE
Perf(optims): improve perfs

### DIFF
--- a/source/optims/constantFolding.ts
+++ b/source/optims/constantFolding.ts
@@ -48,7 +48,6 @@ function initFoldingCtx(
 ): FoldingCtx {
   const refs: RefMaps = { parents: new Map(), childs: new Map() }
 
-  console.time(`> > initFoldingCtx.forEach`)
   Object.entries(parsedRules).forEach(([ruleName, ruleNode]) => {
     const reducedAST =
       reduceAST(
@@ -64,7 +63,9 @@ function initFoldingCtx(
         new Set(),
         ruleNode.explanation.valeur,
       ) ?? new Set()
-    const traversedVariables: RuleName[] = Array.from(reducedAST)
+    const traversedVariables: RuleName[] = Array.from(reducedAST).filter(
+      (name) => !name.endsWith(' . $SITUATION'),
+    )
 
     if (traversedVariables.length > 0) {
       addMapEntry(refs.childs, ruleName, traversedVariables)
@@ -270,6 +271,7 @@ export function removeInMap<K, V>(
     (map.get(key) ?? []).filter((v) => v !== val),
   )
 }
+
 function removeRuleFromRefs(ref: RefMap, ruleName: RuleName) {
   ref.forEach((_, rule) => {
     removeInMap(ref, rule, ruleName)
@@ -417,9 +419,7 @@ export function constantFolding(
   params?: FoldingParams,
 ): ParsedRules<RuleName> {
   const parsedRules: ParsedRules<RuleName> = engine.getParsedRules()
-  console.time('> initFoldingCtx')
   let ctx: FoldingCtx = initFoldingCtx(engine, parsedRules, toKeep, params)
-  console.timeEnd('> initFoldingCtx')
 
   Object.entries(ctx.parsedRules).forEach(([ruleName, ruleNode]) => {
     if (isFoldable(ruleNode) && !isAlreadyFolded(ctx.params, ruleNode)) {


### PR DESCRIPTION
Partially fixes https://github.com/incubateur-ademe/nosgestesclimat/issues/1812 by removing `$SITUATION` rules from references and only evaluating needed rules.

## Perf

The compiled publicodes model specs:
- 17 regions
- 2 languages
- 1654 rules for the base model

The machine specs:
```
CPU(s):                  8
  On-line CPU(s) list:   0-7
Vendor ID:               GenuineIntel
  Model name:            Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
    CPU family:          6
    Model:               142
    Thread(s) per core:  2
    Core(s) per socket:  4
    Socket(s):           1
    Stepping:            10
    CPU max MHz:         3400,0000
    CPU min MHz:         400,0000
Caches (sum of all):     
  L1d:                   128 KiB (4 instances)
  L1i:                   128 KiB (4 instances)
  L2:                    1 MiB (4 instances)
  L3:                    6 MiB (1 instance)
```

### Previous version

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `yarn run compile:rules` | 33.891 ± 0.243 | 33.500 | 34.098 | 7.51 ± 0.10 |
| `yarn run compile:rules -o FR` | 7.971 ± 0.099 | 7.880 | 8.142 | 1.77 ± 0.03 |
| `yarn run compile:rules -o FR -t fr` | 4.516 ± 0.051 | 4.428 | 4.570 | 1.00 |

### Current version

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `yarn run compile:rules` | 27.471 ± 1.051 | 25.158 | 28.470 | 6.85 ± 0.29 |
| `yarn run compile:rules -o FR` | 7.432 ± 0.109 | 7.270 | 7.648 | 1.85 ± 0.04 |
| `yarn run compile:rules -o FR -t fr` | 4.011 ± 0.070 | 3.904 | 4.083 | 1.00 |