### PR TITLE
Compilation: avoid silent overwriting when importing rules

### DIFF
--- a/source/compilation/getModelFromSource.ts
+++ b/source/compilation/getModelFromSource.ts
@@ -34,6 +34,7 @@ function throwErrorIfDuplicatedRules(
  * @throws {Error} If the package name is missing in the macro.
  * @throws {Error} If the rule to import does not exist.
  * @throws {Error} If there is double definition of a rule.
+ * @throws {Error} If there is a conflict between an imported rule and a base rule.
  */
 export function getModelFromSource(
   sourceFile: string,

--- a/test/compilation/data/namespace-conflicts/file1.publicodes
+++ b/test/compilation/data/namespace-conflicts/file1.publicodes
@@ -1,0 +1,10 @@
+importer!:
+  depuis:
+    nom: 'my-external-package'
+    source: '../my-external-package.model.json'
+  dans: pkg
+  les règles:
+    - root . b
+
+rule:
+  formule: pkg . root . b * 2

--- a/test/compilation/data/namespace-conflicts/file2.publicodes
+++ b/test/compilation/data/namespace-conflicts/file2.publicodes
@@ -1,0 +1,2 @@
+pkg:
+  titre: Already existing namespace

--- a/test/compilation/data/rules-doublon.publicodes
+++ b/test/compilation/data/rules-doublon.publicodes
@@ -2,9 +2,8 @@ importer!:
   depuis:
     nom: 'my-external-package'
     source: './my-external-package.model.json'
-  dans: pkg
   les règles:
     - root . b
 
-pkg . root . c:
+my-external-package . root . c:
   titre: Conflicting rule with dependency of 'root . b' in my-external-package

--- a/test/compilation/getModelFromSource.test.ts
+++ b/test/compilation/getModelFromSource.test.ts
@@ -11,6 +11,7 @@ describe('getModelFromSource › rules import', () => {
       getModelFromSource(join(testDataDir, 'simple-import.publicodes')),
     ).toEqual({
       'my-external-package': null,
+      'my-external-package . root': null,
       'my-external-package . root . a': {
         formule: 10,
         description: updatedDescription,
@@ -23,6 +24,7 @@ describe('getModelFromSource › rules import', () => {
       getModelFromSource(join(testDataDir, 'deps-import.publicodes')),
     ).toEqual({
       'my-external-package': null,
+      'my-external-package . root': null,
       'my-external-package . root . b': {
         formule: 'root . c * 2',
         description: updatedDescription,
@@ -63,6 +65,7 @@ describe('getModelFromSource › rules import', () => {
       getModelFromSource(join(testDataDir, 'updated-attrs-import.publicodes')),
     ).toEqual({
       'my-external-package': null,
+      'my-external-package . root': null,
       'my-external-package . root . a': {
         formule: 10,
         titre: "Ajout d'un titre",
@@ -97,6 +100,7 @@ Ajout d'une description`,
       ),
     ).toEqual({
       'my-external-package': null,
+      'my-external-package . root': null,
       'my-external-package . root . b': {
         formule: 'root . c * 2',
         description: updatedDescription,
@@ -229,6 +233,30 @@ Ajout d'une description`,
     const baseName = 'rules-doublon-with-namespace.publicodes'
     expect(() => {
       getModelFromSource(join(testDataDir, baseName))
-    }).toThrow(`[${baseName}] La règle 'pkg' est déjà définie`)
+    }).toThrow(`[${baseName}] La règle 'pkg . root . c' est déjà définie`)
+  })
+
+  it('should not add namespace if it is already present in the model', () => {
+    expect(
+      getModelFromSource(
+        join(testDataDir, 'namespace-conflicts/**.publicodes'),
+      ),
+    ).toEqual({
+      pkg: {
+        titre: 'Already existing namespace',
+      },
+      'pkg . root': null,
+      'pkg . root . b': {
+        formule: 'root . c * 2',
+        description: updatedDescription,
+      },
+      'pkg . root . c': {
+        formule: 20,
+        description: updatedDescription,
+      },
+      rule: {
+        formule: 'pkg . root . b * 2',
+      },
+    })
   })
 })

--- a/test/compilation/getModelFromSource.test.ts
+++ b/test/compilation/getModelFromSource.test.ts
@@ -183,6 +183,15 @@ Ajout d'une description`,
     const baseName = 'rules-doublon.publicodes'
     expect(() => {
       getModelFromSource(join(testDataDir, baseName))
+    }).toThrow(
+      `[${baseName}] La règle 'my-external-package . root . c' est déjà définie`,
+    )
+  })
+
+  it('should throw an error if there is conflict between an imported rule and a base rule with a custom namespace', () => {
+    const baseName = 'rules-doublon-with-namespace.publicodes'
+    expect(() => {
+      getModelFromSource(join(testDataDir, baseName))
     }).toThrow(`[${baseName}] La règle 'pkg . root . c' est déjà définie`)
   })
 
@@ -227,13 +236,6 @@ Ajout d'une description`,
         description: updatedDescription,
       },
     })
-  })
-
-  it('should throw an error if there is conflict between an imported rule and a base rule with a custom namespace', () => {
-    const baseName = 'rules-doublon-with-namespace.publicodes'
-    expect(() => {
-      getModelFromSource(join(testDataDir, baseName))
-    }).toThrow(`[${baseName}] La règle 'pkg . root . c' est déjà définie`)
   })
 
   it('should not add namespace if it is already present in the model', () => {


### PR DESCRIPTION
Implements https://github.com/incubateur-ademe/publicodes-tools/issues/23

By default rules are imported in a new namespace corresponding to its name, and it adds all needed _empty_ namespaces. 