### PR TITLE
fix: resolved 'avec' mechanism are now removed

### DIFF
--- a/source/commons.ts
+++ b/source/commons.ts
@@ -85,7 +85,16 @@ export function getRawNodes(parsedRules: ParsedRules<RuleName>): RawRules {
   return Object.fromEntries(
     Object.values(parsedRules).reduce((acc, rule) => {
       const { nom, ...rawNode } = rule.rawNode
-      acc.push([nom, rawNode])
+      // We don't want to keep the `avec` attribute in the raw node
+      // as they are already resolved in the [parsedRules] object.
+      delete rawNode['avec']
+
+      acc.push([
+        rule.dottedName,
+        // If the rule only contained the 'nom' attribute, we don't want to
+        // keep an empty object in the raw node.
+        Object.keys(rawNode).length === 0 ? null : rawNode,
+      ])
       return acc
     }, []),
   ) as RawRules

--- a/test/getRawRules.test.ts
+++ b/test/getRawRules.test.ts
@@ -13,7 +13,7 @@ describe('getRawRules', () => {
   })
   it('Single null rule', () => {
     expect(getRawNodesWith({ test1: null })).toStrictEqual({
-      test1: {},
+      test1: null,
     })
   })
   it('Simple single rule', () => {
@@ -41,5 +41,29 @@ describe('getRawRules', () => {
       },
     }
     expect(getRawNodesWith(rawRules)).toStrictEqual(rawRules)
+  })
+  it('Mechansim [avec] should not create empty objects', () => {
+    const rawRules = {
+      ruleA: {
+        avec: {
+          bus: null,
+        },
+        titre: 'Rule A',
+        formule: 'B . C * 3',
+      },
+      'ruleA . B . C': {
+        valeur: '10',
+      },
+    }
+    expect(getRawNodesWith(rawRules)).toStrictEqual({
+      ruleA: {
+        titre: 'Rule A',
+        formule: 'B . C * 3',
+      },
+      'ruleA . B . C': {
+        valeur: '10',
+      },
+      'ruleA . bus': null,
+    })
   })
 })


### PR DESCRIPTION
As rules defined in `avec` are resolved in a rule in a full namespace in `parsedRules` we want to removed them from the `rawNode` and use the `dottedName` instead of the `nom` to get the full rule. Plus, we want to keep `null` instead of `{}` to preserve the semantic.