### PR TITLE
pkg: upgrade publicodes to 1.0.0 (NGC-454)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^18.11.18",
-    "publicodes": "^1.0.0-rc.5"
+    "publicodes": "^1.0.0-rc.6"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^18.11.18",
-    "publicodes": "^1.0.0-beta.77"
+    "publicodes": "^1.0.0-rc.5"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^18.11.18",
-    "publicodes": "^1.0.0-rc.6"
+    "publicodes": "^1.0.0-rc.7"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",

--- a/source/commons.ts
+++ b/source/commons.ts
@@ -67,7 +67,7 @@ export type ImportMacro = {
 /**
  * Represents a non-parsed NGC rule.
  */
-export type RawRule = Omit<Rule, 'nom'> & ImportMacro
+export type RawRule = Omit<Rule, 'nom'> | ImportMacro
 
 /**
  * Represents a non-parsed NGC model.

--- a/source/commons.ts
+++ b/source/commons.ts
@@ -115,7 +115,7 @@ export const disabledLogger: Logger = {
  *
  * @returns The references.
  */
-export function getAllRefsInNode(node: RuleNode): RuleName[] {
+export function getAllRefsInNode(node: ASTNode): RuleName[] {
   return reduceAST<RuleName[]>(
     (refs: RuleName[], node: ASTNode) => {
       if (node === undefined) {

--- a/source/compilation/resolveImports.ts
+++ b/source/compilation/resolveImports.ts
@@ -162,21 +162,6 @@ ${importedRule.description}`
   }
 }
 
-/**
- * @throws {Error} If the `nom` attribute is different from the `ruleNameToCheck`.
- */
-function removeRawNodeNom(
-  rawNode: Rule,
-  ruleNameToCheck: string,
-): Omit<Rule, 'nom'> {
-  const { nom, ...rest } = rawNode
-  if (nom !== ruleNameToCheck)
-    throw Error(
-      `Imported rule's publicode raw node "nom" attribute is different from the resolveImport script ruleName. Please investigate`,
-    )
-  return rest
-}
-
 function appearsMoreThanOnce(
   rulesToImport: RuleToImport[],
   ruleName: RuleName,
@@ -252,10 +237,7 @@ export function resolveImports(
           utils
             .ruleParents(ruleName)
             .forEach((rule) => neededNamespaces.add(`${namespace} . ${rule}`))
-          return [
-            `${namespace} . ${ruleName}`,
-            removeRawNodeNom(ruleWithUpdatedDescription, ruleName),
-          ]
+          return [`${namespace} . ${ruleName}`, ruleWithUpdatedDescription]
         }
 
         const ruleWithOverridenAttributes = { ...rule.rawNode, ...attrs }

--- a/source/compilation/resolveImports.ts
+++ b/source/compilation/resolveImports.ts
@@ -203,7 +203,7 @@ export function resolveImports(
   let neededNamespaces = new Set<string>()
   const resolvedRules = Object.entries(rules).reduce((acc, [name, value]) => {
     if (name === IMPORT_KEYWORD) {
-      const importMacro: ImportMacro = value
+      const importMacro = value as ImportMacro
       const engine = getEngine(filePath, importMacro, verbose)
       const rulesToImport: RuleToImport[] =
         importMacro['les règles']?.map(getRuleToImportInfos)

--- a/source/optims/constantFolding.ts
+++ b/source/optims/constantFolding.ts
@@ -78,6 +78,9 @@ function initFoldingCtx(
           ) {
             contextRules.add(ruleName)
             contextRules.add(node.rawNode.valeur)
+            Object.keys(node.rawNode.contexte).map((dottedNameInContext) =>
+              contextRules.add(dottedNameInContext),
+            )
           }
           if (
             node.nodeKind === 'reference' &&

--- a/source/optims/constantFolding.ts
+++ b/source/optims/constantFolding.ts
@@ -72,7 +72,11 @@ function initFoldingCtx(
     const reducedAST =
       reduceAST(
         (acc: Set<RuleName>, node: ASTNode) => {
-          if (Object.keys(node.rawNode).includes('contexte')) {
+          if (
+            node.rawNode != null &&
+            Object.keys(node.rawNode).includes('contexte')
+          ) {
+            contextRules.add(ruleName)
             contextRules.add(node.rawNode.valeur)
           }
           if (
@@ -86,6 +90,7 @@ function initFoldingCtx(
         new Set(),
         ruleNode.explanation.valeur,
       ) ?? new Set()
+
     const traversedVariables: RuleName[] = Array.from(reducedAST).filter(
       (name) => !name.endsWith(' . $SITUATION'),
     )
@@ -118,7 +123,6 @@ function isFoldable(
 
   const rawNode = rule.rawNode
 
-  console.log(rule.dottedName, contextRules, contextRules.has(rule.dottedName))
   return !(
     contextRules.has(rule.dottedName) ||
     'question' in rawNode ||

--- a/source/optims/constantFolding.ts
+++ b/source/optims/constantFolding.ts
@@ -131,8 +131,7 @@ function isFoldable(
 }
 
 function isEmptyRule(rule: RuleNode): boolean {
-  // There is always a 'nom' attribute.
-  return Object.keys(rule.rawNode).length <= 1
+  return Object.keys(rule.rawNode).length === 0
 }
 
 function formatPublicodesUnit(unit?: Unit): string {

--- a/source/optims/constantFolding.ts
+++ b/source/optims/constantFolding.ts
@@ -390,17 +390,9 @@ function tryToFoldRule(
     return
   }
 
-  ctx.engine.cache.traversedVariablesStack = []
-  const { nodeValue, missingVariables, traversedVariables, unit } =
-    ctx.engine.evaluateNode(rule)
+  const { nodeValue, missingVariables, unit } = ctx.engine.evaluateNode(rule)
 
-  const traversedVariablesWithoutSelf = traversedVariables.filter(
-    (dottedName) => dottedName !== ruleName,
-  )
-
-  // NOTE(@EmileRolley): we need to evaluate due to possible standalone rule [formule]
-  // parsed as a [valeur].
-  if ('valeur' in rule.rawNode && traversedVariablesWithoutSelf?.length > 0) {
+  if ('valeur' in rule.rawNode) {
     rule.rawNode.formule = rule.rawNode.valeur
     delete rule.rawNode.valeur
   }
@@ -429,16 +421,7 @@ function tryToFoldRule(
       // it from the [refs].
       const childs = ctx.refs.childs.get(ruleName) ?? []
 
-      updateRefCounting(
-        ctx,
-        ruleName,
-        // NOTE(@EmileRolley): for some reason, the [traversedVariables] are not always
-        // depencies of the rule. Consequently, we need to keep only the ones that are
-        // in the [childs] list in order to avoid removing rules that are not dependencies.
-        traversedVariablesWithoutSelf?.filter((v: RuleName) =>
-          childs.includes(v),
-        ) ?? [],
-      )
+      updateRefCounting(ctx, ruleName, childs)
       delete ctx.parsedRules[ruleName].rawNode.formule
     }
 

--- a/source/optims/constantFolding.ts
+++ b/source/optims/constantFolding.ts
@@ -346,6 +346,7 @@ function tryToFoldRule(
     return
   }
 
+  ctx.engine.cache.traversedVariablesStack = []
   const { nodeValue, missingVariables, traversedVariables, unit } =
     ctx.engine.evaluateNode(rule)
 

--- a/source/optims/constantFolding.ts
+++ b/source/optims/constantFolding.ts
@@ -31,17 +31,16 @@ type FoldingCtx = {
   toKeep?: PredicateOnRule
   params: FoldingParams
   /**
-   * The rules that are evaluated with a modified situation (in a [recalcul] mechanism)
+   * The rules that are evaluated with a modified situation (in a [contexte] mechanism)
    * and we don't want to be folded.
    *
    * @example
    * ```
    * rule:
-   *   recalcul:
-   *	    règle: rule2
-   *	    avec:
-   *	      rule3: 10
-   *	      rule4: 20
+   *	  valeur: rule2
+   *	  contexte:
+   *	    rule3: 10
+   *	    rule4: 20
    * ...
    * ```
    * In this case, [rule2] should not be folded.
@@ -74,10 +73,10 @@ function initFoldingCtx(
       reduceAST(
         (acc: Set<RuleName>, node: ASTNode) => {
           if (
-            node.nodeKind === 'recalcul' &&
-            'dottedName' in node.explanation.recalculNode
+            Object.keys(node.rawNode).includes('contexte') &&
+            node.rawNode.valeur !== undefined
           ) {
-            recalculRules.add(node.explanation.recalculNode.dottedName)
+            recalculRules.add(node.rawNode.valeur)
           }
           if (
             node.nodeKind === 'reference' &&

--- a/source/optims/constantFolding.ts
+++ b/source/optims/constantFolding.ts
@@ -78,9 +78,6 @@ function initFoldingCtx(
           ) {
             contextRules.add(ruleName)
             contextRules.add(node.rawNode.valeur)
-            Object.keys(node.rawNode.contexte).map((dottedNameInContext) =>
-              contextRules.add(dottedNameInContext),
-            )
           }
           if (
             node.nodeKind === 'reference' &&

--- a/test/getRawRules.test.ts
+++ b/test/getRawRules.test.ts
@@ -36,6 +36,7 @@ describe('getRawRules', () => {
         titre: 'Rule A',
         formule: 'B . C * 3',
       },
+      'ruleA . B': null,
       'ruleA . B . C': {
         valeur: '10',
       },
@@ -51,6 +52,7 @@ describe('getRawRules', () => {
         titre: 'Rule A',
         formule: 'B . C * 3',
       },
+      'ruleA . B': null,
       'ruleA . B . C': {
         valeur: '10',
       },
@@ -60,6 +62,7 @@ describe('getRawRules', () => {
         titre: 'Rule A',
         formule: 'B . C * 3',
       },
+      'ruleA . B': null,
       'ruleA . B . C': {
         valeur: '10',
       },

--- a/test/optims/constantFolding.test.ts
+++ b/test/optims/constantFolding.test.ts
@@ -585,6 +585,42 @@ describe('Constant folding [base]', () => {
     })
   })
 
+  it('should not fold rules used with a [contexte] impacting a complex formula', () => {
+    const rawRules = {
+      root: {
+        formule: {
+          somme: ['rule to recompute', 10],
+        },
+        contexte: {
+          constant: 20,
+        },
+      },
+      'rule to recompute': {
+        formule: 'constant * 2',
+      },
+      constant: {
+        valeur: 10,
+      },
+    }
+    expect(constantFoldingWith(rawRules)).toStrictEqual({
+      root: {
+        formule: {
+          somme: ['rule to recompute', 10],
+        },
+        contexte: {
+          constant: 20,
+        },
+      },
+      'rule to recompute': {
+        formule: 'constant * 2',
+      },
+      constant: {
+        valeur: 10,
+        optimized: true,
+      },
+    })
+  })
+
   it('should not fold rules used with a [contexte] but still fold used constant in other rules', () => {
     const rawRules = {
       root: {

--- a/test/optims/constantFolding.test.ts
+++ b/test/optims/constantFolding.test.ts
@@ -539,14 +539,12 @@ describe('Constant folding [base]', () => {
     })
   })
 
-  it('should not fold rules used in a [recalcul]', () => {
+  it('should not fold rules used with a [contexte]', () => {
     const rawRules = {
       root: {
-        recalcul: {
-          règle: 'rule to recompute',
-          avec: {
-            constant: 20,
-          },
+        valeur: 'rule to recompute',
+        contexte: {
+          constant: 20,
         },
       },
       'rule to recompute': {
@@ -558,11 +556,9 @@ describe('Constant folding [base]', () => {
     }
     expect(constantFoldingWith(rawRules)).toStrictEqual({
       root: {
-        recalcul: {
-          règle: 'rule to recompute',
-          avec: {
-            constant: 20,
-          },
+        valeur: 'rule to recompute',
+        contexte: {
+          constant: 20,
         },
       },
       'rule to recompute': {
@@ -575,14 +571,12 @@ describe('Constant folding [base]', () => {
     })
   })
 
-  it('should not fold rules used in a [recalcul] but still fold used constant in other rules', () => {
+  it('should not fold rules used with a [contexte] but still fold used constant in other rules', () => {
     const rawRules = {
       root: {
-        recalcul: {
-          règle: 'rule to recompute',
-          avec: {
-            constant: 20,
-          },
+        valeur: 'rule to recompute',
+        contexte: {
+          constant: 20,
         },
       },
       'rule to recompute': {
@@ -597,11 +591,9 @@ describe('Constant folding [base]', () => {
     }
     expect(constantFoldingWith(rawRules)).toStrictEqual({
       root: {
-        recalcul: {
-          règle: 'rule to recompute',
-          avec: {
-            constant: 20,
-          },
+        valeur: 'rule to recompute',
+        contexte: {
+          constant: 20,
         },
       },
       'rule to recompute': {

--- a/test/optims/constantFolding.test.ts
+++ b/test/optims/constantFolding.test.ts
@@ -143,6 +143,7 @@ describe('Constant folding [base]', () => {
       'ruleA . D': {
         question: "What's the value of D?",
       },
+      'ruleA . B': null,
       'ruleA . B . C': {
         valeur: '10',
       },
@@ -164,6 +165,7 @@ describe('Constant folding [base]', () => {
         titre: 'Rule A',
         formule: 'B . C * D',
       },
+      'ruleA . B': null,
       ruleB: {
         formule: 'ruleA . B . C * 3',
       },
@@ -240,6 +242,7 @@ describe('Constant folding [base]', () => {
       ruleB: {
         somme: ['A . B * 2', 10, 12 * 2],
       },
+      A: null,
       'A . B': {
         formule: 'C * 10',
       },
@@ -267,6 +270,7 @@ describe('Constant folding [base]', () => {
       'ruleB . D': {
         question: "What's the value of ruleB . D?",
       },
+      A: null,
       'A . B': {
         formule: 'C * 10',
       },
@@ -363,6 +367,7 @@ describe('Constant folding [base]', () => {
       "biogaz . facteur d'émission": {
         valeur: 20,
       },
+      gaz: null,
       "gaz . facteur d'émission": {
         valeur: 10,
       },
@@ -389,6 +394,7 @@ describe('Constant folding [base]', () => {
       "biogaz . facteur d'émission": {
         valeur: 20,
       },
+      gaz: null,
       "gaz . facteur d'émission": {
         valeur: 10,
       },
@@ -515,6 +521,10 @@ describe('Constant folding [base]', () => {
   })
   it('should work with parentheses inside [formule]', () => {
     const rawRules = {
+      divers: null,
+      'divers . ameublement': null,
+      'divers . ameublement . meubles': null,
+      'divers . ameublement . meubles . armoire': null,
       'divers . ameublement . meubles . armoire . empreinte amortie': {
         titre: 'Empreinte armoire amortie',
         formule: 'armoire . empreinte / (durée * coefficient préservation)',

--- a/test/optims/constantFolding.test.ts
+++ b/test/optims/constantFolding.test.ts
@@ -553,7 +553,7 @@ describe('Constant folding [base]', () => {
     })
   })
 
-  it('should not fold rules used with a [contexte]', () => {
+  it('should not fold rules impacted by a [contexte]', () => {
     const rawRules = {
       root: {
         valeur: 'rule to recompute',
@@ -580,12 +580,97 @@ describe('Constant folding [base]', () => {
       },
       constant: {
         valeur: 10,
-        optimized: true,
+        // TODO: should be marked as optimized?
+        // optimized: true,
       },
     })
   })
 
-  it('should not fold rules used with a [contexte] impacting a complex formula', () => {
+  it('should not fold nested rules impacted by a [contexte]', () => {
+    const rawRules = {
+      root: {
+        valeur: 'rule to recompute',
+        contexte: {
+          constant: 20,
+        },
+      },
+      'rule to recompute': {
+        formule: 'rule to recompute . nested * 2',
+      },
+      'rule to recompute . nested': {
+        formule: 'constant * 4',
+      },
+      constant: {
+        valeur: 10,
+      },
+    }
+    expect(constantFoldingWith(rawRules)).toStrictEqual({
+      root: {
+        valeur: 'rule to recompute',
+        contexte: {
+          constant: 20,
+        },
+      },
+      'rule to recompute': {
+        formule: 'rule to recompute . nested * 2',
+      },
+      'rule to recompute . nested': {
+        formule: 'constant * 4',
+      },
+      constant: {
+        valeur: 10,
+        // TODO: should be marked as optimized?
+        // optimized: true,
+      },
+    })
+  })
+
+  it('should not fold nested rules (2 deep) impacted by a [contexte]', () => {
+    const rawRules = {
+      root: {
+        valeur: 'rule to recompute',
+        contexte: {
+          constant: 20,
+        },
+      },
+      'rule to recompute': {
+        formule: 'nested 1 * 2',
+      },
+      'rule to recompute . nested 1': {
+        formule: 'nested 2 * 4',
+      },
+      'rule to recompute . nested 2': {
+        formule: 'constant * 4',
+      },
+      constant: {
+        valeur: 10,
+      },
+    }
+    expect(constantFoldingWith(rawRules)).toStrictEqual({
+      root: {
+        valeur: 'rule to recompute',
+        contexte: {
+          constant: 20,
+        },
+      },
+      'rule to recompute': {
+        formule: 'nested 1 * 2',
+      },
+      'rule to recompute . nested 1': {
+        formule: 'nested 2 * 4',
+      },
+      'rule to recompute . nested 2': {
+        formule: 'constant * 4',
+      },
+      constant: {
+        valeur: 10,
+        // TODO: should be marked as optimized?
+        // optimized: true,
+      },
+    })
+  })
+
+  it('should not fold rules impacted by a [contexte] with nested mechanisms in the formula', () => {
     const rawRules = {
       root: {
         formule: {
@@ -616,7 +701,8 @@ describe('Constant folding [base]', () => {
       },
       constant: {
         valeur: 10,
-        optimized: true,
+        // TODO: should be marked as optimized?
+        // optimized: true,
       },
     })
   })
@@ -655,7 +741,8 @@ describe('Constant folding [base]', () => {
       },
       constant: {
         valeur: 10,
-        optimized: true,
+        // TODO: should be marked as optimized?
+        // optimized: true,
       },
     })
   })

--- a/test/optims/constantFolding.test.ts
+++ b/test/optims/constantFolding.test.ts
@@ -27,6 +27,7 @@ describe('Constant folding [meta]', () => {
         titre: 'Rule A',
         formule: 'B . C * D',
       },
+      'ruleA . B': null,
       'ruleA . B . C': {
         valeur: '10',
       },
@@ -70,6 +71,7 @@ describe('Constant folding [base]', () => {
         titre: 'Rule A',
         formule: 'B . C * 3',
       },
+      'ruleA . B': null,
       'ruleA . B . C': {
         valeur: '10',
       },
@@ -88,6 +90,7 @@ describe('Constant folding [base]', () => {
         titre: 'Rule A',
         formule: 'B . C * D',
       },
+      'ruleA . B': null,
       'ruleA . B . C': {
         valeur: '10',
       },
@@ -112,6 +115,7 @@ describe('Constant folding [base]', () => {
       'ruleA . D': {
         question: "What's the value of D",
       },
+      'ruleA . B': null,
       'ruleA . B . C': {
         valeur: '10',
       },

--- a/test/optims/constantFolding.test.ts
+++ b/test/optims/constantFolding.test.ts
@@ -640,6 +640,9 @@ describe('Constant folding [base]', () => {
         formule: 'nested 2 * 4',
       },
       'rule to recompute . nested 2': {
+        formule: 'nested 3 * 4',
+      },
+      'rule to recompute . nested 3': {
         formule: 'constant * 4',
       },
       constant: {
@@ -660,6 +663,9 @@ describe('Constant folding [base]', () => {
         formule: 'nested 2 * 4',
       },
       'rule to recompute . nested 2': {
+        formule: 'nested 3 * 4',
+      },
+      'rule to recompute . nested 3': {
         formule: 'constant * 4',
       },
       constant: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,10 +2331,10 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-publicodes@^1.0.0-rc.6:
-  version "1.0.0-rc.6"
-  resolved "https://registry.yarnpkg.com/publicodes/-/publicodes-1.0.0-rc.6.tgz#c102984a8c9dad599c56a8b9a00ccaf599b6a581"
-  integrity sha512-fT5KB+zSEUE0PfO76zpId4w1BVSEhAM27zZ1c5MPz9wwkRjDWLijHwyt90C9lkzRQ2OvatEkMXbAmRegQ/gKVA==
+publicodes@^1.0.0-rc.7:
+  version "1.0.0-rc.7"
+  resolved "https://registry.yarnpkg.com/publicodes/-/publicodes-1.0.0-rc.7.tgz#2ed0ce1d091674646477d5fd4d6411daaa283a0c"
+  integrity sha512-Y5WZ1t9BCRJxGFDsOflq0sFyryp7gFe05A9txHfvsW+DMjejnAgvC9O4enaU4+/4fI7+N62jxCWNsmStwqy/ZQ==
 
 punycode@^2.1.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,10 +2331,10 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-publicodes@^1.0.0-rc.5:
-  version "1.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/publicodes/-/publicodes-1.0.0-rc.5.tgz#714a600ccaa78ad89da878973999402e29996130"
-  integrity sha512-y5ZxhiBDf/GjSPE9iwoSlcwFNogqhxwl45LrVrGuWeIORgdALTdtHQaPgItQpaKVRSdsZei2GoCnsAIfqLCTJw==
+publicodes@^1.0.0-rc.6:
+  version "1.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/publicodes/-/publicodes-1.0.0-rc.6.tgz#c102984a8c9dad599c56a8b9a00ccaf599b6a581"
+  integrity sha512-fT5KB+zSEUE0PfO76zpId4w1BVSEhAM27zZ1c5MPz9wwkRjDWLijHwyt90C9lkzRQ2OvatEkMXbAmRegQ/gKVA==
 
 punycode@^2.1.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2331,10 +2331,10 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-publicodes@^1.0.0-beta.77:
-  version "1.0.0-beta.77"
-  resolved "https://registry.yarnpkg.com/publicodes/-/publicodes-1.0.0-beta.77.tgz#45e3c4d2a46bfadcc932e1405ea037e659c28134"
-  integrity sha512-F8U3WGUWMo3/rxhWYS1gWIiG20g1Yy/+PpXdHM99d6ZHKWnnyh/4txVEuyVE75glgDs+mTjwZPnmoKWsTMXluA==
+publicodes@^1.0.0-rc.5:
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/publicodes/-/publicodes-1.0.0-rc.5.tgz#714a600ccaa78ad89da878973999402e29996130"
+  integrity sha512-y5ZxhiBDf/GjSPE9iwoSlcwFNogqhxwl45LrVrGuWeIORgdALTdtHQaPgItQpaKVRSdsZei2GoCnsAIfqLCTJw==
 
 punycode@^2.1.0:
   version "2.3.0"


### PR DESCRIPTION
> [!IMPORTANT]
> Pour l'instant toutes les **règles dont un de leurs parents contient un mécanisme `contexte` ne sont pas optimisées**. On passe donc de 962 règles à 1147 dans la version optimisée. 
> Des améliorations pourraient être fait pour optimiser les règles enfants qui le peuvent mais pour l'instant je préfère opter pour la solution simple et qui assure que les résultats du calcul sont fiables (cf. le commentaire dans `constantFolding.ts`).