### PR TITLE
build!: fix packaging to correctly support both esm and cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@publicodes/tools",
   "version": "1.0.7",
   "description": "A set of utility functions to build tools around Publicodes models",
+  "type": "module",
   "scripts": {
     "build": "tsup",
     "watch": "tsup --watch",
@@ -78,7 +79,9 @@
     "allowJs": true,
     "sourceMap": true,
     "dts": true,
-    "clean": true
+    "clean": true,
+    "target": "es2020",
+    "skipNodeModulesBundle": true
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
I had some troubles when importing the `@publicodes/tools` package from `publicodes-language-server` which use commonjs. This fix seems to work everywhere.